### PR TITLE
Create parts cache collection during deployment

### DIFF
--- a/post-install.xql
+++ b/post-install.xql
@@ -9,7 +9,21 @@ declare variable $dir external;
 (: the target collection into which the app is deployed :)
 declare variable $target external;
 
+declare function local:create-parts-cache-collection() {
+    let $collection := $target || "/cache"
+    return (
+        if (xmldb:collection-available($collection)) then
+            ()
+        else
+            xmldb:create-collection($target, "cache"),
+        sm:chown(xs:anyURI($collection), "guest"),
+        sm:chgrp(xs:anyURI($collection), "guest"),
+        sm:chmod(xs:anyURI($collection), "rwx------")
+    )
+};
+
 xmldb:create-collection($target, "data"),
 sm:chmod(xs:anyURI($target || "/data"), "rwxrwxr-x"),
 sm:chown(xs:anyURI($target || "/data"), "tei"),
-sm:chgrp(xs:anyURI($target || "/data"), "tei")
+sm:chgrp(xs:anyURI($target || "/data"), "tei"),
+local:create-parts-cache-collection()


### PR DESCRIPTION
Adds the /db/apps/bebb-data/cache setup to post-install.xql so the api/parts cache collection is recreated and configured during data app deployment.